### PR TITLE
Explicitly drop heap allocation for FFI.

### DIFF
--- a/src/action/ffi.rs
+++ b/src/action/ffi.rs
@@ -18,7 +18,10 @@ pub unsafe extern "C" fn redirectionio_action_json_deserialize(str: *mut c_char)
 
     let action = match json_decode(action_str) {
         Err(error) => {
-            error!("Unable to deserialize \"{}\" to action: {}", action_str, error,);
+            error!(
+                "Unable to deserialize \"{}\" to action: {}",
+                action_str, error,
+            );
 
             return null() as *const Action;
         }
@@ -32,7 +35,9 @@ pub unsafe extern "C" fn redirectionio_action_json_deserialize(str: *mut c_char)
 /// Serialize an action to a string
 ///
 /// Returns null if an error happens
-pub unsafe extern "C" fn redirectionio_action_json_serialize(_action: *mut Action) -> *const c_char {
+pub unsafe extern "C" fn redirectionio_action_json_serialize(
+    _action: *mut Action,
+) -> *const c_char {
     if _action.is_null() {
         return null();
     }
@@ -56,11 +61,14 @@ pub unsafe extern "C" fn redirectionio_action_drop(_action: *mut Action) {
         return;
     }
 
-    Box::from_raw(_action);
+    drop(Box::from_raw(_action));
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn redirectionio_action_get_status_code(_action: *mut Action, response_status_code: u16) -> u16 {
+pub unsafe extern "C" fn redirectionio_action_get_status_code(
+    _action: *mut Action,
+    response_status_code: u16,
+) -> u16 {
     if _action.is_null() {
         return 0;
     }
@@ -107,7 +115,10 @@ pub unsafe extern "C" fn redirectionio_action_body_filter_create(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn redirectionio_action_body_filter_filter(_filter: *mut FilterBodyAction, buffer: Buffer) -> Buffer {
+pub unsafe extern "C" fn redirectionio_action_body_filter_filter(
+    _filter: *mut FilterBodyAction,
+    buffer: Buffer,
+) -> Buffer {
     if _filter.is_null() {
         return buffer.duplicate();
     }
@@ -126,7 +137,9 @@ pub unsafe extern "C" fn redirectionio_action_body_filter_filter(_filter: *mut F
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn redirectionio_action_body_filter_close(_filter: *mut FilterBodyAction) -> Buffer {
+pub unsafe extern "C" fn redirectionio_action_body_filter_close(
+    _filter: *mut FilterBodyAction,
+) -> Buffer {
     if _filter.is_null() {
         return Buffer::default();
     }
@@ -143,7 +156,7 @@ pub unsafe extern "C" fn redirectionio_action_body_filter_drop(_filter: *mut Fil
         return;
     }
 
-    Box::from_raw(_filter);
+    drop(Box::from_raw(_filter));
 }
 
 #[no_mangle]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -46,7 +46,10 @@ pub unsafe extern "C" fn redirectionio_router_create(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn redirectionio_router_route_add(_route: *mut Route<Rule>, _router: *mut Router<Rule>) {
+pub unsafe extern "C" fn redirectionio_router_route_add(
+    _route: *mut Route<Rule>,
+    _router: *mut Router<Rule>,
+) {
     let route = Box::from_raw(_route);
     let router = &mut *_router;
 
@@ -54,7 +57,10 @@ pub unsafe extern "C" fn redirectionio_router_route_add(_route: *mut Route<Rule>
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn redirectionio_router_route_remove(_route_id: *const c_char, _router: *mut Router<Rule>) {
+pub unsafe extern "C" fn redirectionio_router_route_remove(
+    _route_id: *const c_char,
+    _router: *mut Router<Rule>,
+) {
     if _router.is_null() {
         return;
     }
@@ -76,11 +82,14 @@ pub unsafe extern "C" fn redirectionio_router_drop(_router: *mut Router<Rule>) {
         return;
     }
 
-    Box::from_raw(_router);
+    drop(Box::from_raw(_router));
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn redirectionio_router_match_action(_router: *const Router<Rule>, _request: *const Request) -> *const Action {
+pub unsafe extern "C" fn redirectionio_router_match_action(
+    _router: *const Router<Rule>,
+    _request: *const Request,
+) -> *const Action {
     if _router.is_null() || _request.is_null() {
         return null() as *const Action;
     }
@@ -95,7 +104,10 @@ pub unsafe extern "C" fn redirectionio_router_match_action(_router: *const Route
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn redirectionio_router_trace(_router: *const Router<Rule>, _request: *const Request) -> *const RouterTrace {
+pub unsafe extern "C" fn redirectionio_router_trace(
+    _router: *const Router<Rule>,
+    _request: *const Request,
+) -> *const RouterTrace {
     if _router.is_null() || _request.is_null() {
         return null() as *const RouterTrace;
     }
@@ -109,7 +121,10 @@ pub unsafe extern "C" fn redirectionio_router_trace(_router: *const Router<Rule>
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn redirectionio_router_impact(_router: *const Router<Rule>, _impact: *const Impact) -> *const Vec<ImpactResultItem> {
+pub unsafe extern "C" fn redirectionio_router_impact(
+    _router: *const Router<Rule>,
+    _impact: *const Impact,
+) -> *const Vec<ImpactResultItem> {
     if _router.is_null() {
         return null() as *const Vec<ImpactResultItem>;
     }

--- a/src/http/ffi.rs
+++ b/src/http/ffi.rs
@@ -57,7 +57,9 @@ pub unsafe fn header_map_to_http_headers(header_map: *const HeaderMap) -> Vec<He
 
 #[no_mangle]
 /// # Safety
-pub unsafe extern "C" fn redirectionio_request_json_deserialize(str: *mut c_char) -> *const Request {
+pub unsafe extern "C" fn redirectionio_request_json_deserialize(
+    str: *mut c_char,
+) -> *const Request {
     let request_str = match c_char_to_str(str) {
         None => return null() as *const Request,
         Some(str) => str,
@@ -65,7 +67,10 @@ pub unsafe extern "C" fn redirectionio_request_json_deserialize(str: *mut c_char
 
     let request = match json_decode(request_str) {
         Err(err) => {
-            error!("cannot deserialize request {} for string {}", err, request_str);
+            error!(
+                "cannot deserialize request {} for string {}",
+                err, request_str
+            );
 
             return null() as *const Request;
         }
@@ -77,7 +82,9 @@ pub unsafe extern "C" fn redirectionio_request_json_deserialize(str: *mut c_char
 
 #[no_mangle]
 /// # Safety
-pub unsafe extern "C" fn redirectionio_request_json_serialize(_request: *const Request) -> *const c_char {
+pub unsafe extern "C" fn redirectionio_request_json_serialize(
+    _request: *const Request,
+) -> *const c_char {
     if _request.is_null() {
         return null();
     }
@@ -126,7 +133,9 @@ pub unsafe extern "C" fn redirectionio_request_create(
 
 #[no_mangle]
 /// # Safety
-pub unsafe extern "C" fn redirectionio_trusted_proxies_create(_proxies_str: *const c_char) -> *const TrustedProxies {
+pub unsafe extern "C" fn redirectionio_trusted_proxies_create(
+    _proxies_str: *const c_char,
+) -> *const TrustedProxies {
     let mut trusted_proxies = TrustedProxies::default();
 
     if let Some(proxies_str) = c_char_to_str(_proxies_str) {
@@ -146,7 +155,10 @@ pub unsafe extern "C" fn redirectionio_trusted_proxies_create(_proxies_str: *con
 
 #[no_mangle]
 /// # Safety
-pub unsafe extern "C" fn redirectionio_trusted_proxies_add_proxy(_trusted_proxies: *mut TrustedProxies, _proxy_str: *const c_char) {
+pub unsafe extern "C" fn redirectionio_trusted_proxies_add_proxy(
+    _trusted_proxies: *mut TrustedProxies,
+    _proxy_str: *const c_char,
+) {
     if _trusted_proxies.is_null() {
         return;
     }
@@ -214,5 +226,5 @@ pub unsafe extern "C" fn redirectionio_request_drop(_request: *mut Request) {
         return;
     }
 
-    Box::from_raw(_request);
+    drop(Box::from_raw(_request));
 }


### PR DESCRIPTION
`Box::from_raw` is tagged `#[must_use]`, so we explicitly call the drop of `Box` to silent this warning