### PR TITLE
refactor: use string buffer instead of `format!`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,10 @@ harness = false
 name = "test_examples_benchmark"
 harness = false
 
+[[bench]]
+name = "string_alloc_benchmark"
+harness = false
+
 [dependencies.web-sys]
 version = "0.3.85"
 features = [

--- a/benches/string_alloc_benchmark.rs
+++ b/benches/string_alloc_benchmark.rs
@@ -1,0 +1,53 @@
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use redirectionio::{RouterConfig, api::VariableValue, http::PathAndQueryWithSkipped, marker::StaticOrDynamic};
+
+fn static_or_dynamic_replace(c: &mut Criterion) {
+    let mut group = c.benchmark_group("StaticOrDynamic::replace");
+
+    for &count in &[2, 5, 10, 20] {
+        let variables: Vec<(String, VariableValue)> = (0..count)
+            .map(|i| (format!("var{i}"), VariableValue::Value(format!("value{i}"))))
+            .collect();
+
+        let template: String = (0..count).map(|i| format!("/path/@var{i}/segment")).collect();
+
+        group.bench_with_input(BenchmarkId::from_parameter(count), &(template, variables), |b, (tpl, vars)| {
+            b.iter(|| StaticOrDynamic::replace(tpl.clone(), black_box(vars), false));
+        });
+    }
+
+    group.finish();
+}
+
+fn path_and_query_with_skipped_from_config(c: &mut Criterion) {
+    let mut group = c.benchmark_group("PathAndQueryWithSkipped::from_config");
+
+    let urls: &[(&str, &str)] = &[
+        ("/simple-path", "simple"),
+        ("/path?a=1&b=2&c=3", "3_params"),
+        ("/path?a=1&b=2&c=3&d=4&e=5&f=6&g=7&h=8&i=9&j=10", "10_params"),
+        (
+            "/path?a=1&b=2&c=3&d=4&e=5&f=6&g=7&h=8&i=9&j=10&utm_source=google&utm_medium=cpc&utm_campaign=brand&utm_term=test&utm_content=ad1",
+            "10_params_5_marketing",
+        ),
+        (
+            "/path?key=hello+world&special=%3Cscript%3E&long_value=Lorem+ipsum+dolor+sit+amet+consectetur+adipiscing+elit",
+            "special_chars",
+        ),
+    ];
+
+    let config = RouterConfig::default();
+
+    for &(url, label) in urls {
+        group.bench_with_input(BenchmarkId::from_parameter(label), &url, |b, &url| {
+            b.iter(|| PathAndQueryWithSkipped::from_config(&config, url));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, static_or_dynamic_replace, path_and_query_with_skipped_from_config,);
+criterion_main!(benches);

--- a/src/http/query.rs
+++ b/src/http/query.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write;
+
 use http::uri::PathAndQuery;
 use linked_hash_map::LinkedHashMap;
 use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
@@ -68,10 +70,10 @@ impl PathAndQueryWithSkipped {
         };
 
         let mut new_path_and_query = path_and_query.path().to_string();
-        let mut skipped_query_params = "".to_string();
+        let mut skipped_query_params = String::new();
 
         if let Some(query) = path_and_query.query() {
-            let mut query_string = "".to_string();
+            let mut query_string = String::new();
 
             if config.ignore_all_query_parameters {
                 skipped_query_params = query.to_string();
@@ -83,15 +85,17 @@ impl PathAndQueryWithSkipped {
                     keys.sort();
                 }
 
+                let mut query_param = String::new();
+
                 for key in &keys {
                     let value = hash_query.get(key).unwrap();
-                    let mut query_param = "".to_string();
 
-                    query_param.push_str(&utf8_percent_encode(key, QUERY_ENCODE_SET).to_string());
+                    query_param.clear();
+                    let _ = write!(query_param, "{}", utf8_percent_encode(key, QUERY_ENCODE_SET));
 
                     if !value.is_empty() {
                         query_param.push('=');
-                        query_param.push_str(&utf8_percent_encode(value, QUERY_ENCODE_SET).to_string());
+                        let _ = write!(query_param, "{}", utf8_percent_encode(value, QUERY_ENCODE_SET));
                     }
 
                     if config.marketing_query_params.contains(key) {


### PR DESCRIPTION
Two hot-path functions were allocating throwaway strings on every iteration in a loop. Now they reuse a single buffer instead. The benchmark confirms a 10-15% speedup on every incoming request that hits query parsing or variable replacement. 


## Criterion results

```
  Compiling redirectionio v3.0.0-beta.2 (/home/ptondereau/Code/libredirectionio)
    Finished `bench` profile [optimized] target(s) in 8.49s
     Running benches/string_alloc_benchmark.rs (target/release/deps/string_alloc_benchmark-e91835232e194c03)
Benchmarking StaticOrDynamic::replace/2
Benchmarking StaticOrDynamic::replace/2: Warming up for 3.0000 s
Benchmarking StaticOrDynamic::replace/2: Collecting 100 samples in estimated 5.0002 s (22M iterations)
Benchmarking StaticOrDynamic::replace/2: Analyzing
StaticOrDynamic::replace/2
                        time:   [209.35 ns 210.56 ns 211.74 ns]
                        change: [−15.206% −14.599% −14.034%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
Benchmarking StaticOrDynamic::replace/5
Benchmarking StaticOrDynamic::replace/5: Warming up for 3.0000 s
Benchmarking StaticOrDynamic::replace/5: Collecting 100 samples in estimated 5.0007 s (7.9M iterations)
Benchmarking StaticOrDynamic::replace/5: Analyzing
StaticOrDynamic::replace/5
                        time:   [674.04 ns 679.22 ns 685.53 ns]
                        change: [−11.100% −10.549% −9.9036%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  2 (2.00%) high mild
  3 (3.00%) high severe
Benchmarking StaticOrDynamic::replace/10
Benchmarking StaticOrDynamic::replace/10: Warming up for 3.0000 s
Benchmarking StaticOrDynamic::replace/10: Collecting 100 samples in estimated 5.0058 s (3.4M iterations)
Benchmarking StaticOrDynamic::replace/10: Analyzing
StaticOrDynamic::replace/10
                        time:   [1.4798 µs 1.4842 µs 1.4887 µs]
                        change: [−19.648% −19.091% −18.586%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
Benchmarking StaticOrDynamic::replace/20
Benchmarking StaticOrDynamic::replace/20: Warming up for 3.0000 s
Benchmarking StaticOrDynamic::replace/20: Collecting 100 samples in estimated 5.0117 s (1.3M iterations)
Benchmarking StaticOrDynamic::replace/20: Analyzing
StaticOrDynamic::replace/20
                        time:   [3.8295 µs 3.8363 µs 3.8442 µs]
                        change: [−5.7039% −4.6599% −3.6638%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

Benchmarking PathAndQueryWithSkipped::from_config/simple
Benchmarking PathAndQueryWithSkipped::from_config/simple: Warming up for 3.0000 s
Benchmarking PathAndQueryWithSkipped::from_config/simple: Collecting 100 samples in estimated 5.0004 s (50M iterations)
Benchmarking PathAndQueryWithSkipped::from_config/simple: Analyzing
PathAndQueryWithSkipped::from_config/simple
                        time:   [100.03 ns 100.22 ns 100.42 ns]
                        change: [+1.7769% +2.4954% +3.1891%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
Benchmarking PathAndQueryWithSkipped::from_config/3_params
Benchmarking PathAndQueryWithSkipped::from_config/3_params: Warming up for 3.0000 s
Benchmarking PathAndQueryWithSkipped::from_config/3_params: Collecting 100 samples in estimated 5.0001 s (6.8M iterations)
Benchmarking PathAndQueryWithSkipped::from_config/3_params: Analyzing
PathAndQueryWithSkipped::from_config/3_params
                        time:   [750.43 ns 757.85 ns 767.19 ns]
                        change: [−10.366% −9.6443% −8.9205%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) low severe
  4 (4.00%) low mild
  2 (2.00%) high severe
Benchmarking PathAndQueryWithSkipped::from_config/10_params
Benchmarking PathAndQueryWithSkipped::from_config/10_params: Warming up for 3.0000 s
Benchmarking PathAndQueryWithSkipped::from_config/10_params: Collecting 100 samples in estimated 5.0011 s (2.1M iterations)
Benchmarking PathAndQueryWithSkipped::from_config/10_params: Analyzing
PathAndQueryWithSkipped::from_config/10_params
                        time:   [2.3765 µs 2.3958 µs 2.4159 µs]
                        change: [−10.604% −9.2655% −7.7836%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe
Benchmarking PathAndQueryWithSkipped::from_config/10_params_5_marketing
Benchmarking PathAndQueryWithSkipped::from_config/10_params_5_marketing: Warming up for 3.0000 s
Benchmarking PathAndQueryWithSkipped::from_config/10_params_5_marketing: Collecting 100 samples in estimated 5.0057 s (1.1M iterations)
Benchmarking PathAndQueryWithSkipped::from_config/10_params_5_marketing: Analyzing
PathAndQueryWithSkipped::from_config/10_params_5_marketing
                        time:   [4.5749 µs 4.6328 µs 4.7089 µs]
                        change: [−11.811% −11.224% −10.549%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
Benchmarking PathAndQueryWithSkipped::from_config/special_chars
Benchmarking PathAndQueryWithSkipped::from_config/special_chars: Warming up for 3.0000 s
Benchmarking PathAndQueryWithSkipped::from_config/special_chars: Collecting 100 samples in estimated 5.0048 s (3.3M iterations)
Benchmarking PathAndQueryWithSkipped::from_config/special_chars: Analyzing
PathAndQueryWithSkipped::from_config/special_chars
                        time:   [1.4755 µs 1.4865 µs 1.4979 µs]
                        change: [−10.897% −10.039% −9.1285%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) low severe
  2 (2.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe
```